### PR TITLE
Make build and install scripts more portable

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 version=$(git describe --exact-match --tags 2>/dev/null || git describe 2>/dev/null || echo "prerelease")
 go build \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Without this change the scripts do not execute properly on systems where bash is not located at `/bin/bash` (i.e. FreeBSD)