### PR TITLE
Make getting the up-time more portable across unix-like systems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.16.6'
+        go-version: '^1.17'
     - run: go version
     
     - name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/internal/app/darktile/hinters/hint_dmesg_timestamp.go
+++ b/internal/app/darktile/hinters/hint_dmesg_timestamp.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/liamg/darktile/internal/app/darktile/termutil"
@@ -52,7 +51,5 @@ func (h *DmesgTimestampHinter) Click(api HintAPI) error {
 }
 
 func setSysStartTime() {
-	sysInfo := &syscall.Sysinfo_t{}
-	_ = syscall.Sysinfo(sysInfo)
-	sysStart = time.Now().Local().Add(time.Duration(int(sysInfo.Uptime*-1)) * time.Second)
+	sysStart = time.Now().Local().Add(time.Duration(int(getUptime()*-1)) * time.Second)
 }

--- a/internal/app/darktile/hinters/uptime.go
+++ b/internal/app/darktile/hinters/uptime.go
@@ -1,4 +1,5 @@
-//go:build cgo && (!linux || unix)
+//go:build cgo && (freebsd || openbsd)
+
 package hinters
 
 /*

--- a/internal/app/darktile/hinters/uptime.go
+++ b/internal/app/darktile/hinters/uptime.go
@@ -1,0 +1,22 @@
+//go:build cgo && (!linux || unix)
+package hinters
+
+/*
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/timespec.h>
+
+
+time_t getuptime() {
+	struct timespec tp;
+	clock_gettime(CLOCK_UPTIME, &tp);
+	return tp.tv_sec;
+}
+*/
+import "C"
+
+func getUptime() int64 {
+	time := C.getuptime()
+	return int64(time)
+}

--- a/internal/app/darktile/hinters/uptime_builtin.go
+++ b/internal/app/darktile/hinters/uptime_builtin.go
@@ -1,3 +1,5 @@
+//go:build cgo && (linux || netbsd)
+
 package hinters
 
 import (

--- a/internal/app/darktile/hinters/uptime_linux.go
+++ b/internal/app/darktile/hinters/uptime_linux.go
@@ -1,0 +1,11 @@
+package hinters
+
+import (
+	"syscall"
+)
+
+func getUptime() int64 {
+	sysInfo := &syscall.Sysinfo_t{}
+	_ = syscall.Sysinfo(sysInfo)
+	return sysInfo.Uptime
+}


### PR DESCRIPTION
This fixes #324