### PR TITLE
Fix terminal state and key state data races

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .vscode
 /darktile
+*.swp

--- a/internal/app/darktile/gui/gui.go
+++ b/internal/app/darktile/gui/gui.go
@@ -102,12 +102,12 @@ func (g *GUI) Run() error {
 func (g *GUI) watchForUpdate() {
 	for range g.updateChan {
 		ebiten.ScheduleFrame()
-		go func() {
-			if g.keyState.AnythingPressed() {
+		if g.keyState.AnythingPressed() {
+			go func() {
 				time.Sleep(time.Millisecond * 10)
 				ebiten.ScheduleFrame()
-			}
-		}()
+			}()
+		}
 	}
 }
 

--- a/internal/app/darktile/gui/input.go
+++ b/internal/app/darktile/gui/input.go
@@ -37,6 +37,8 @@ var modifiableKeys = map[ebiten.Key]uint8{
 }
 
 func (g *GUI) handleInput() error {
+	g.terminal.Lock()
+	defer g.terminal.Unlock()
 
 	if err := g.handleMouse(); err != nil {
 		return err

--- a/internal/app/darktile/gui/key_states.go
+++ b/internal/app/darktile/gui/key_states.go
@@ -30,6 +30,8 @@ type press struct {
 }
 
 func (k *keyState) AnythingPressed() bool {
+	k.mu.Lock()
+	defer k.mu.Unlock()
 	return len(k.keys) > 0
 }
 

--- a/internal/app/darktile/gui/render/render.go
+++ b/internal/app/darktile/gui/render/render.go
@@ -62,6 +62,8 @@ func New(screen *ebiten.Image, terminal *termutil.Terminal, fontManager *font.Ma
 }
 
 func (r *Render) Draw() {
+	r.terminal.Lock()
+	defer r.terminal.Unlock()
 
 	// 1. fill frame with default background colour
 	r.frame.Fill(r.theme.DefaultBackground())

--- a/internal/app/darktile/gui/resize.go
+++ b/internal/app/darktile/gui/resize.go
@@ -22,14 +22,17 @@ func (g *GUI) Layout(outsideWidth, outsideHeight int) (int, int) {
 
 func (g *GUI) resize(w, h int) {
 
-	if g.fontManager.CharSize().X == 0 || g.fontManager.CharSize().Y == 0 {
+	if g.fontManager.CharSize().X == 0 || g.fontManager.CharSize().Y == 0 || g.terminal == nil {
 		return
 	}
 
 	cols := uint16(w / g.fontManager.CharSize().X)
 	rows := uint16(h / g.fontManager.CharSize().Y)
 
-	if g.terminal != nil && g.terminal.IsRunning() {
+	g.terminal.Lock()
+	defer g.terminal.Unlock()
+
+	if g.terminal.IsRunning() {
 		_ = g.terminal.SetSize(rows, cols)
 	}
 }

--- a/internal/app/darktile/termutil/ansi.go
+++ b/internal/app/darktile/termutil/ansi.go
@@ -6,6 +6,9 @@ func (t *Terminal) handleANSI(readChan chan MeasuredRune) (renderRequired bool) 
 
 	t.log("ANSI SEQ %c 0x%X", r.Rune, r.Rune)
 
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	switch r.Rune {
 	case '[':
 		return t.handleCSI(readChan)


### PR DESCRIPTION
I am using darktile for an internal project and stumbled upon a few data races. In essence, we are processing input via `io.Copy->Terminal.Write->handleInput` concurrently without synchronizing with the main rendering loop (`GUI.Update->...->g.terminal.GetActiveBuffer`).

I haven't done any analysis on contention but at first glance we might be adding some, since we are blocking on internal calls to `WriteToPty` etc. This solution was enough for my purposes so feel free to close PR if you think a more sophisticated approach is required.