### PR TITLE
ANSI CSI 22m should also turn off bold

### DIFF
--- a/internal/app/darktile/termutil/csi.go
+++ b/internal/app/darktile/termutil/csi.go
@@ -929,6 +929,7 @@ func (t *Terminal) sgrSequenceHandler(params []string) bool {
 			t.GetActiveBuffer().getCursorAttr().bold = false
 		case "22":
 			t.GetActiveBuffer().getCursorAttr().dim = false
+			t.GetActiveBuffer().getCursorAttr().bold = false
 		case "23":
 			t.GetActiveBuffer().getCursorAttr().italic = false
 		case "24":

--- a/internal/app/darktile/termutil/csi.go
+++ b/internal/app/darktile/termutil/csi.go
@@ -911,7 +911,9 @@ func (t *Terminal) sgrSequenceHandler(params []string) bool {
 			*attr = CellAttributes{}
 		case "1", "01":
 			t.GetActiveBuffer().getCursorAttr().bold = true
+			t.GetActiveBuffer().getCursorAttr().dim = false
 		case "2", "02":
+			t.GetActiveBuffer().getCursorAttr().bold = false
 			t.GetActiveBuffer().getCursorAttr().dim = true
 		case "3", "03":
 			t.GetActiveBuffer().getCursorAttr().italic = true


### PR DESCRIPTION
https://en.wikipedia.org/wiki/ANSI_escape_code

Can test in a different terminal with:
```
printf "\e[1mHELLO \e[22mhello \e[0m\n"
```